### PR TITLE
Native Implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,102 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Chromium
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunctionBody: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.4
   - 2.4.1
   - ruby-head
 before_install: gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'activerecord', gem_version, group: :test
 
 group :benchmarks do
   gem 'sqlite3'
+  gem 'pg'
 
   gem 'memory_profiler'
   gem 'ruby-prof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     panko (0.1.8)
       concurrent-ruby
-      oj (~> 3.1.3)
+      oj (~> 3.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -68,7 +68,7 @@ GEM
     minitest (5.10.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
-    oj (3.1.4)
+    oj (3.2.0)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panko (0.1.8)
+    panko (0.2.0)
       concurrent-ruby
       oj (~> 3.2.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     oj (3.2.0)
+    pg (0.21.0)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -145,6 +146,7 @@ DEPENDENCIES
   faker
   memory_profiler
   panko!
+  pg
   rails (~> 4.2.8)
   railties (~> 4.2.8)
   rake (~> 10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panko (0.2.0)
+    panko (0.2.1)
       concurrent-ruby
       oj (~> 3.2.0)
 
@@ -158,4 +158,4 @@ DEPENDENCIES
   terminal-table
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.5.0)
+    rake-compiler (1.0.4)
+      rake
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -146,6 +148,7 @@ DEPENDENCIES
   rails (~> 4.2.8)
   railties (~> 4.2.8)
   rake (~> 10.0)
+  rake-compiler
   rspec (~> 3.0)
   ruby-prof
   ruby-prof-flamegraph

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panko (0.2.1)
+    panko (0.2.2)
       concurrent-ruby
       oj (~> 3.2.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -34,13 +34,18 @@ end
 
 desc 'Run all benchmarks'
 task :benchmarks do
-  run_benchmarks Dir[File.join(__dir__, 'benchmarks', 'bm_*')]
+  run_benchmarks Dir[File.join(__dir__, 'benchmarks', '**', 'bm_*')]
+end
+
+desc 'Type Casts - Benchmarks'
+task :bm_type_casts do
+  run_benchmarks Dir[File.join(__dir__, 'benchmarks', 'type_casts', 'bm_*')]
 end
 
 desc 'Sanity Benchmarks'
 task :sanity do
-  puts Time.now.strftime("%d/%m %H:%M:%S")
-  puts "=========================="
+  puts Time.now.strftime('%d/%m %H:%M:%S')
+  puts '=========================='
 
   run_benchmarks [
     File.join(__dir__, 'benchmarks', 'sanity.rb')

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,10 @@ Rake::ExtensionTask.new('panko') do |ext|
 end
 
 RSpec::Core::RakeTask.new(:spec)
+Rake::Task[:spec].prerequisites << :compile
 
-task default: [:compile, :spec]
+
+task default: :spec
 
 desc 'Run all benchmarks'
 task :benchmarks do

--- a/Rakefile
+++ b/Rakefile
@@ -2,14 +2,15 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'json'
 require 'terminal-table'
-
 require 'rake/extensiontask'
-spec = Gem::Specification.load('panko.gemspec')
-Rake::ExtensionTask.new('panko', spec)
+
+Rake::ExtensionTask.new('panko') do |ext|
+  ext.lib_dir = 'lib/panko'
+end
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task default: [:compile, :spec]
 
 desc 'Run all benchmarks'
 task :benchmarks do

--- a/Rakefile
+++ b/Rakefile
@@ -14,13 +14,11 @@ Rake::Task[:spec].prerequisites << :compile
 
 task default: :spec
 
-desc 'Run all benchmarks'
-task :benchmarks do
-  headings = ['Benchmark', 'ip/s', 'allocs/retained']
 
-  files = Dir[File.join(__dir__, 'benchmarks', 'bm_*')]
+def run_benchmarks(files, items_count: 14_000)
+  headings = ['Benchmark', 'ip/s', 'allocs/retained']
   files.each do |benchmark_file|
-    output = `RAILS_ENV=production ruby #{benchmark_file}`
+    output = `ITEMS_COUNT=#{items_count} RAILS_ENV=production ruby #{benchmark_file}`
 
     rows = output.each_line.map do |line|
       result = JSON.parse(line)
@@ -32,5 +30,21 @@ task :benchmarks do
     table = Terminal::Table.new title: title, headings: headings, rows: rows
     puts table
   end
+end
 
+desc 'Run all benchmarks'
+task :benchmarks do
+  run_benchmarks Dir[File.join(__dir__, 'benchmarks', 'bm_*')]
+end
+
+desc 'Sanity Benchmarks'
+task :sanity do
+  puts Time.now.strftime("%d/%m %H:%M:%S")
+  puts "=========================="
+
+  run_benchmarks [
+    File.join(__dir__, 'benchmarks', 'sanity.rb')
+  ], items_count: 2300
+
+  puts "\n\n"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@ require 'rspec/core/rake_task'
 require 'json'
 require 'terminal-table'
 
+require 'rake/extensiontask'
+spec = Gem::Specification.load('panko.gemspec')
+Rake::ExtensionTask.new('panko', spec)
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/benchmarks/benchmarking_support.rb
+++ b/benchmarks/benchmarking_support.rb
@@ -29,7 +29,7 @@ module Benchmark
 
       results = {
         label: label,
-        ips: report.entries.first.ips.round(2),
+        ips: ActiveSupport::NumberHelper.number_to_delimited(report.entries.first.ips.round(2)),
         allocs: "#{memory_report.total_allocated}/#{memory_report.total_retained}"
       }.to_json
 

--- a/benchmarks/bm_panko_json.rb
+++ b/benchmarks/bm_panko_json.rb
@@ -11,6 +11,14 @@ class PostFastSerializer < Panko::Serializer
   attributes :id, :body, :title, :author_id
 end
 
+class PostFastWithMethodCallSerializer < Panko::Serializer
+  attributes :id, :body, :title, :author_id, :method_call
+
+  def method_call
+    object.id * 2
+  end
+end
+
 class PostWithHasOneFastSerializer < Panko::Serializer
   attributes :id, :body, :title, :author_id
 
@@ -42,27 +50,10 @@ def benchmark(prefix, serializer, options = {})
   Benchmark.ams("Panko_#{prefix}_Posts_50") do
     Panko::ArraySerializer.new(posts_50, merged_options).to_json
   end
-
-  posts_array_serializer = Panko::ArraySerializer.new([], merged_options)
-
-  data = Benchmark.data
-  posts = data[:all]
-  posts_50 = data[:small]
-
-  Benchmark.ams("Panko_Reused_#{prefix}_Posts_#{posts.count}") do
-    posts_array_serializer.serialize_to_json posts
-  end
-
-  data = Benchmark.data
-  posts = data[:all]
-  posts_50 = data[:small]
-
-  Benchmark.ams("Panko_Reused_#{prefix}_Posts_50") do
-    posts_array_serializer.serialize_to_json posts_50
-  end
 end
 
 benchmark 'HasOne', PostWithHasOneFastSerializer
 benchmark 'Simple', PostFastSerializer
+benchmark 'SimpleWithMethodCall', PostFastWithMethodCallSerializer
 benchmark 'Except', PostWithHasOneFastSerializer, except: [:title]
 benchmark 'Include', PostWithHasOneFastSerializer, include: [:id, :body, :author_id, :author]

--- a/benchmarks/setup.rb
+++ b/benchmarks/setup.rb
@@ -50,12 +50,14 @@ class Profile < ActiveRecord::Base
 end
 
 # Build out the data to serialize
-14_000.times do
-  Post.create(
-    body: 'something about how password restrictions are evil, and less secure, and with the math to prove it.',
-    title: 'Your bank is does not know how to do security',
-    author: Author.create(name: 'Preston Sego')
-  )
+Post.transaction do
+  ENV.fetch('ITEMS_COUNT', '2300').to_i.times do
+    Post.create(
+      body: 'something about how password restrictions are evil, and less secure, and with the math to prove it.',
+      title: 'Your bank is does not know how to do security',
+      author: Author.create(name: 'Preston Sego')
+    )
+  end
 end
 
 

--- a/benchmarks/type_casts/bm_active_record.rb
+++ b/benchmarks/type_casts/bm_active_record.rb
@@ -1,0 +1,42 @@
+require_relative './support'
+
+def ar_type_convert(type_klass, from, to)
+  converter = type_klass.new
+  assert type_klass.name, converter.type_cast_from_database(from), to
+
+  Benchmark.ams("#{type_klass.name}_TypeCast") do
+    converter.type_cast_from_database(from)
+  end
+
+  Benchmark.ams("#{type_klass.name}_NoTypeCast") do
+    converter.type_cast_from_database(to)
+  end
+end
+
+def ar_time
+  type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime.new
+  converter = ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter.new(type)
+
+  from = '2017-07-10 09:26:40.937392'
+  to = converter.type_cast_from_database(from)
+
+  Benchmark.ams("#{type.class.name}_TypeCast") do
+    converter.type_cast_from_database(from)
+  end
+
+  Benchmark.ams("#{type.class.name}_NoTypeCast") do
+    converter.type_cast_from_database(to)
+  end
+end
+
+ar_type_convert ActiveRecord::Type::String, 1, '1'
+ar_type_convert ActiveRecord::Type::Text, 1, '1'
+ar_type_convert ActiveRecord::Type::Integer, '1', 1
+ar_type_convert ActiveRecord::Type::Float, '1.23', 1.23
+ar_type_convert ActiveRecord::Type::Float, 'Infinity', 0.0
+
+ar_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer, '1', 1
+ar_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, '1.23', 1.23
+ar_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, 'Infinity', ::Float::INFINITY
+ar_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json, '{"a":1}', {a:1}
+ar_time

--- a/benchmarks/type_casts/bm_active_record.rb
+++ b/benchmarks/type_casts/bm_active_record.rb
@@ -34,6 +34,8 @@ ar_type_convert ActiveRecord::Type::Text, 1, '1'
 ar_type_convert ActiveRecord::Type::Integer, '1', 1
 ar_type_convert ActiveRecord::Type::Float, '1.23', 1.23
 ar_type_convert ActiveRecord::Type::Float, 'Infinity', 0.0
+ar_type_convert ActiveRecord::Type::Boolean, 'true', true
+ar_type_convert ActiveRecord::Type::Boolean, 't', true
 
 ar_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer, '1', 1
 ar_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, '1.23', 1.23

--- a/benchmarks/type_casts/bm_panko.rb
+++ b/benchmarks/type_casts/bm_panko.rb
@@ -18,6 +18,8 @@ panko_type_convert ActiveRecord::Type::Text, 1, '1'
 panko_type_convert ActiveRecord::Type::Integer, '1', 1
 panko_type_convert ActiveRecord::Type::Float, '1.23', 1.23
 panko_type_convert ActiveRecord::Type::Float, 'Infinity', ::Float::INFINITY
+panko_type_convert ActiveRecord::Type::Boolean, 'true', true
+panko_type_convert ActiveRecord::Type::Boolean, 't', true
 
 panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer, '1', 1
 panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, '1.23', 1.23

--- a/benchmarks/type_casts/bm_panko.rb
+++ b/benchmarks/type_casts/bm_panko.rb
@@ -1,0 +1,27 @@
+require_relative './support'
+
+def panko_type_convert(type_klass, from, to)
+  converter = type_klass.new
+  assert "#{type_klass.name}", Panko::_type_cast(converter, from), to
+
+  Benchmark.ams("#{type_klass.name}_TypeCast") do
+    Panko::_type_cast(converter, from)
+  end
+
+  Benchmark.ams("#{type_klass.name}_NoTypeCast") do
+    Panko::_type_cast(converter, to)
+  end
+end
+
+panko_type_convert ActiveRecord::Type::String, 1, '1'
+panko_type_convert ActiveRecord::Type::Text, 1, '1'
+panko_type_convert ActiveRecord::Type::Integer, '1', 1
+panko_type_convert ActiveRecord::Type::Float, '1.23', 1.23
+panko_type_convert ActiveRecord::Type::Float, 'Infinity', ::Float::INFINITY
+
+panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer, '1', 1
+panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, '1.23', 1.23
+panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, 'Infinity', ::Float::INFINITY
+
+panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json, '{"a":1}', {a:1}
+

--- a/benchmarks/type_casts/bm_pg.rb
+++ b/benchmarks/type_casts/bm_pg.rb
@@ -1,0 +1,35 @@
+require_relative './support'
+
+def pg_type_convert(type_klass, from, to)
+  converter = type_klass.new
+  assert type_klass.name, converter.decode(from), to
+
+  Benchmark.ams("#{type_klass.name}_TypeCast") do
+    converter.decode(from)
+  end
+end
+
+def pg_time
+  decoder = PG::TextDecoder::TimestampWithoutTimeZone.new
+
+  from = '2017-07-10 09:26:40.937392'
+
+  Benchmark.ams("#{decoder.class.name}_TypeCast") do
+    decoder.decode(from)
+  end
+
+  Benchmark.ams("#{decoder.class.name}_TypeCast_InTimeZone") do
+    decoder.decode(from).in_time_zone
+  end
+end
+
+
+
+
+pg_type_convert PG::TextDecoder::Integer, '1', 1
+pg_type_convert PG::TextDecoder::Float, '1.23', 1.23
+pg_type_convert PG::TextDecoder::Float, 'Infinity', ::Float::INFINITY
+pg_type_convert PG::TextDecoder::Float, '-Infinity', ::Float::INFINITY
+pg_type_convert PG::TextDecoder::Float, 'NaN', ::Float::NaN
+pg_time
+

--- a/benchmarks/type_casts/support.rb
+++ b/benchmarks/type_casts/support.rb
@@ -1,0 +1,15 @@
+require 'active_record'
+require 'active_record/connection_adapters/postgresql_adapter'
+require 'active_model'
+require 'active_support/all'
+require 'pg'
+
+
+require_relative '../benchmarking_support'
+require_relative '../../lib/panko/panko'
+
+def assert(type_name, from, to)
+  raise "#{type_name} - #{from.class} is not equals to #{to.class}" unless from.to_json == to.to_json
+end
+
+Time.zone = 'UTC'

--- a/ext/panko/attributes_iterator.c
+++ b/ext/panko/attributes_iterator.c
@@ -1,11 +1,11 @@
 #include "attributes_iterator.h"
 
-static ID	attributes_id = 0;
-static ID	types_id = 0;
-static ID	values_id = 0;
+static ID attributes_id = 0;
+static ID types_id = 0;
+static ID values_id = 0;
 
 VALUE read_attributes(VALUE obj) {
-  if(attributes_id == 0) {
+  if (attributes_id == 0) {
     attributes_id = rb_intern("@attributes");
   }
 
@@ -14,34 +14,38 @@ VALUE read_attributes(VALUE obj) {
 
 VALUE panko_read_lazy_attributes_hash(VALUE object) {
   VALUE attributes_set = read_attributes(object);
-  if(attributes_set == Qnil) {
+  if (attributes_set == Qnil) {
     return Qnil;
   }
 
   VALUE attributes_hash = read_attributes(attributes_set);
-  if(attributes_hash == Qnil) {
+  if (attributes_hash == Qnil) {
     return Qnil;
   }
 
   return attributes_hash;
 }
 
-void panko_read_types_and_value(VALUE attributes_hash, VALUE* types, VALUE* values) {
-  if(types_id == 0) {
+void panko_read_types_and_value(VALUE attributes_hash,
+                                VALUE* types,
+                                VALUE* values) {
+  if (types_id == 0) {
     types_id = rb_intern("@types");
   }
 
   *types = rb_ivar_get(attributes_hash, types_id);
 
-  if(values_id == 0) {
+  if (values_id == 0) {
     values_id = rb_intern("@values");
   }
 
   *values = rb_ivar_get(attributes_hash, values_id);
 }
 
-VALUE panko_each_attribute(VALUE obj, VALUE attributes, EachAttributeFunc func, VALUE context)
-{
+VALUE panko_each_attribute(VALUE obj,
+                           VALUE attributes,
+                           EachAttributeFunc func,
+                           VALUE context) {
   VALUE attributes_hash = panko_read_lazy_attributes_hash(obj);
   // TODO: raise error here if attributes_hash is null
 
@@ -54,7 +58,6 @@ VALUE panko_each_attribute(VALUE obj, VALUE attributes, EachAttributeFunc func, 
 
     VALUE value = rb_hash_aref(values, member);
     VALUE type_metadata = rb_hash_aref(types, member);
-
 
     func(obj, member, value, type_metadata, context);
   }

--- a/ext/panko/attributes_iterator.c
+++ b/ext/panko/attributes_iterator.c
@@ -1,0 +1,63 @@
+#include "attributes_iterator.h"
+
+static ID	attributes_id = 0;
+static ID	types_id = 0;
+static ID	values_id = 0;
+
+VALUE read_attributes(VALUE obj) {
+  if(attributes_id == 0) {
+    attributes_id = rb_intern("@attributes");
+  }
+
+  return rb_ivar_get(obj, attributes_id);
+}
+
+VALUE panko_read_lazy_attributes_hash(VALUE object) {
+  VALUE attributes_set = read_attributes(object);
+  if(attributes_set == Qnil) {
+    return Qnil;
+  }
+
+  VALUE attributes_hash = read_attributes(attributes_set);
+  if(attributes_hash == Qnil) {
+    return Qnil;
+  }
+
+  return attributes_hash;
+}
+
+void panko_read_types_and_value(VALUE attributes_hash, VALUE* types, VALUE* values) {
+  if(types_id == 0) {
+    types_id = rb_intern("@types");
+  }
+
+  *types = rb_ivar_get(attributes_hash, types_id);
+
+  if(values_id == 0) {
+    values_id = rb_intern("@values");
+  }
+
+  *values = rb_ivar_get(attributes_hash, values_id);
+}
+
+VALUE panko_each_attribute(VALUE obj, VALUE attributes, EachAttributeFunc func, VALUE context)
+{
+  VALUE attributes_hash = panko_read_lazy_attributes_hash(obj);
+  // TODO: raise error here if attributes_hash is null
+
+  VALUE types, values;
+  panko_read_types_and_value(attributes_hash, &types, &values);
+
+  int i;
+  for (i = 0; i < RARRAY_LEN(attributes); i++) {
+    VALUE member = rb_sym2str(RARRAY_AREF(attributes, i));
+
+    VALUE value = rb_hash_aref(values, member);
+    VALUE type_metadata = rb_hash_aref(types, member);
+
+
+    func(obj, member, value, type_metadata, context);
+  }
+
+  return Qnil;
+}

--- a/ext/panko/attributes_iterator.c
+++ b/ext/panko/attributes_iterator.c
@@ -5,10 +5,6 @@ static ID types_id = 0;
 static ID values_id = 0;
 
 VALUE read_attributes(VALUE obj) {
-  if (attributes_id == 0) {
-    attributes_id = rb_intern("@attributes");
-  }
-
   return rb_ivar_get(obj, attributes_id);
 }
 
@@ -29,16 +25,7 @@ VALUE panko_read_lazy_attributes_hash(VALUE object) {
 void panko_read_types_and_value(VALUE attributes_hash,
                                 VALUE* types,
                                 VALUE* values) {
-  if (types_id == 0) {
-    types_id = rb_intern("@types");
-  }
-
   *types = rb_ivar_get(attributes_hash, types_id);
-
-  if (values_id == 0) {
-    values_id = rb_intern("@values");
-  }
-
   *values = rb_ivar_get(attributes_hash, values_id);
 }
 
@@ -63,4 +50,10 @@ VALUE panko_each_attribute(VALUE obj,
   }
 
   return Qnil;
+}
+
+void panko_init_attributes_iterator(VALUE mPanko) {
+  attributes_id = rb_intern("@attributes");
+  values_id = rb_intern("@values");
+  types_id = rb_intern("@types");
 }

--- a/ext/panko/attributes_iterator.h
+++ b/ext/panko/attributes_iterator.h
@@ -1,5 +1,12 @@
 #include <ruby.h>
 
-typedef void  (*EachAttributeFunc)(VALUE object, VALUE name, VALUE value, VALUE type_metadata, VALUE context);
+typedef void (*EachAttributeFunc)(VALUE object,
+                                  VALUE name,
+                                  VALUE value,
+                                  VALUE type_metadata,
+                                  VALUE context);
 
-extern VALUE panko_each_attribute(VALUE object, VALUE attributes, EachAttributeFunc func, VALUE context);
+extern VALUE panko_each_attribute(VALUE object,
+                                  VALUE attributes,
+                                  EachAttributeFunc func,
+                                  VALUE context);

--- a/ext/panko/attributes_iterator.h
+++ b/ext/panko/attributes_iterator.h
@@ -1,0 +1,5 @@
+#include <ruby.h>
+
+typedef void  (*EachAttributeFunc)(VALUE object, VALUE name, VALUE value, VALUE type_metadata, VALUE context);
+
+extern VALUE panko_each_attribute(VALUE object, VALUE attributes, EachAttributeFunc func, VALUE context);

--- a/ext/panko/attributes_iterator.h
+++ b/ext/panko/attributes_iterator.h
@@ -10,3 +10,5 @@ extern VALUE panko_each_attribute(VALUE object,
                                   VALUE attributes,
                                   EachAttributeFunc func,
                                   VALUE context);
+
+void panko_init_attributes_iterator(VALUE mPanko);

--- a/ext/panko/extconf.rb
+++ b/ext/panko/extconf.rb
@@ -1,0 +1,5 @@
+require 'mkmf'
+
+extension_name = 'panko'
+dir_config(extension_name)
+create_makefile(extension_name)

--- a/ext/panko/extconf.rb
+++ b/ext/panko/extconf.rb
@@ -1,5 +1,8 @@
 require 'mkmf'
 
+$CPPFLAGS += " -Wall"
+
 extension_name = 'panko'
 dir_config(extension_name)
 create_makefile(extension_name)
+%x{make clean}

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -49,5 +49,6 @@ void Init_panko() {
   VALUE mPanko = rb_define_module("Panko");
   rb_define_singleton_method(mPanko, "process", process, 5);
 
-  init_panko_type_cast(mPanko);
+  panko_init_attributes_iterator(mPanko);
+  panko_init_type_cast(mPanko);
 }

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -3,26 +3,34 @@
 #include "attributes_iterator.h"
 #include "type_cast.h"
 
-static ID	push_value_id = 0;
+static ID push_value_id = 0;
 
-
-void write_value(VALUE str_writer, VALUE key, VALUE value, VALUE type_metadata)
-{
-  if(type_metadata != Qnil) {
+void write_value(VALUE str_writer,
+                 VALUE key,
+                 VALUE value,
+                 VALUE type_metadata) {
+  if (type_metadata != Qnil) {
     value = type_cast(type_metadata, value);
   }
 
   rb_funcall(str_writer, push_value_id, 2, value, key);
 }
 
-void panko_attributes_iter(VALUE object, VALUE name, VALUE value, VALUE type_metadata, VALUE context)
-{
+void panko_attributes_iter(VALUE object,
+                           VALUE name,
+                           VALUE value,
+                           VALUE type_metadata,
+                           VALUE context) {
   write_value(context, name, value, type_metadata);
 }
 
-VALUE process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attributes, VALUE method_calls_attributes)
-{
-  panko_each_attribute(obj, attributes, panko_attributes_iter,  str_writer);
+VALUE process(VALUE klass,
+              VALUE obj,
+              VALUE str_writer,
+              VALUE serializer,
+              VALUE attributes,
+              VALUE method_calls_attributes) {
+  panko_each_attribute(obj, attributes, panko_attributes_iter, str_writer);
 
   long i;
   for (i = 0; i < RARRAY_LEN(method_calls_attributes); i++) {
@@ -35,11 +43,8 @@ VALUE process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE 
   return Qnil;
 }
 
-void
-Init_panko()
-{
+void Init_panko() {
   push_value_id = rb_intern("push_value");
-
 
   VALUE mPanko = rb_define_module("Panko");
   rb_define_singleton_method(mPanko, "process", process, 5);

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -35,8 +35,10 @@ VALUE process(VALUE klass,
   long i;
   for (i = 0; i < RARRAY_LEN(method_calls_attributes); i++) {
     VALUE attribute_name = RARRAY_AREF(method_calls_attributes, i);
+    // TODO: create global cache from attribute_name to rb_sym2id
     VALUE result = rb_funcall(serializer, rb_sym2id(attribute_name), 0);
 
+    // TODO: create global cache from attribute_name to rb_sym2str
     write_value(str_writer, rb_sym2str(attribute_name), result, Qnil);
   }
 

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -1,0 +1,82 @@
+#include <ruby.h>
+
+static ID	attributes_id = 0;
+static ID	push_value_id = 0;
+static ID	types_id = 0;
+static ID	values_id = 0;
+
+
+static VALUE
+read_attributes(VALUE obj) {
+  if (0 == attributes_id) {
+    attributes_id = rb_intern("@attributes");
+  }
+  return rb_ivar_get(obj, attributes_id);
+}
+
+static void
+write_value(VALUE str_writer, VALUE key, VALUE value, VALUE type_metadata)
+{
+  if (0 == push_value_id) {
+    push_value_id = rb_intern("push_value");
+  }
+
+  // TODO: take care of type_metadata
+  // TODO: call directly on oj's push_value
+  rb_funcall(str_writer, push_value_id, 2, value, key);
+}
+
+
+static VALUE
+process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attributes, VALUE method_calls_attributes)
+{
+  VALUE attributes_set = read_attributes(obj);
+  if(attributes_set == Qnil) {
+    return Qnil;
+  }
+  VALUE attributes_hash = read_attributes(attributes_set);
+  if(attributes_hash == Qnil) {
+    return Qnil;
+  }
+
+  if (0 == types_id) {
+    types_id = rb_intern("@types");
+  }
+  VALUE types = rb_ivar_get(attributes_hash, types_id);
+  if(types == Qnil) {
+    return Qnil;
+  }
+
+  if (0 == values_id) {
+    values_id = rb_intern("@values");
+  }
+  VALUE values = rb_ivar_get(attributes_hash, values_id);
+  if(values == Qnil) {
+    return Qnil;
+  }
+
+  for (long i = 0; i < RARRAY_LEN(attributes); i++) {
+    VALUE member = rb_sym2str(RARRAY_AREF(attributes, i));
+
+    VALUE value = rb_hash_aref(values, member);
+    VALUE type_metadata = rb_hash_aref(types, member);
+
+    write_value(str_writer, member, value, type_metadata);
+  }
+
+  for (long i = 0; i < RARRAY_LEN(method_calls_attributes); i++) {
+    VALUE attribute_name = RARRAY_AREF(method_calls_attributes, i);
+    VALUE result = rb_funcall(serializer, rb_sym2id(attribute_name), 0);
+
+    write_value(str_writer, rb_sym2str(attribute_name), result, Qnil);
+  }
+
+  return Qnil;
+}
+
+void
+Init_panko()
+{
+  VALUE mPanko = rb_define_module("Panko");
+  rb_define_singleton_method(mPanko, "process", process, 5);
+}

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -34,6 +34,7 @@ process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attrib
   if(attributes_set == Qnil) {
     return Qnil;
   }
+
   VALUE attributes_hash = read_attributes(attributes_set);
   if(attributes_hash == Qnil) {
     return Qnil;
@@ -55,7 +56,9 @@ process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attrib
     return Qnil;
   }
 
-  for (long i = 0; i < RARRAY_LEN(attributes); i++) {
+  long i;
+
+  for (i = 0; i < RARRAY_LEN(attributes); i++) {
     VALUE member = rb_sym2str(RARRAY_AREF(attributes, i));
 
     VALUE value = rb_hash_aref(values, member);
@@ -64,7 +67,7 @@ process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attrib
     write_value(str_writer, member, value, type_metadata);
   }
 
-  for (long i = 0; i < RARRAY_LEN(method_calls_attributes); i++) {
+  for (i = 0; i < RARRAY_LEN(method_calls_attributes); i++) {
     VALUE attribute_name = RARRAY_AREF(method_calls_attributes, i);
     VALUE result = rb_funcall(serializer, rb_sym2id(attribute_name), 0);
 

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -1,72 +1,29 @@
 #include <ruby.h>
 
-static ID	attributes_id = 0;
+#include "attributes_iterator.h"
+
 static ID	push_value_id = 0;
-static ID	types_id = 0;
-static ID	values_id = 0;
+static ID	type_cast_from_database_id = 0;
 
-
-static VALUE
-read_attributes(VALUE obj) {
-  if (0 == attributes_id) {
-    attributes_id = rb_intern("@attributes");
-  }
-  return rb_ivar_get(obj, attributes_id);
-}
-
-static void
-write_value(VALUE str_writer, VALUE key, VALUE value, VALUE type_metadata)
+void write_value(VALUE str_writer, VALUE key, VALUE value, VALUE type_metadata)
 {
-  if (0 == push_value_id) {
-    push_value_id = rb_intern("push_value");
+  if(type_metadata != Qnil) {
+    value = rb_funcall(type_metadata, type_cast_from_database_id, 1, value);
   }
 
-  // TODO: take care of type_metadata
-  // TODO: call directly on oj's push_value
   rb_funcall(str_writer, push_value_id, 2, value, key);
 }
 
-
-static VALUE
-process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attributes, VALUE method_calls_attributes)
+void panko_attributes_iter(VALUE object, VALUE name, VALUE value, VALUE type_metadata, VALUE context)
 {
-  VALUE attributes_set = read_attributes(obj);
-  if(attributes_set == Qnil) {
-    return Qnil;
-  }
+  write_value(context, name, value, type_metadata);
+}
 
-  VALUE attributes_hash = read_attributes(attributes_set);
-  if(attributes_hash == Qnil) {
-    return Qnil;
-  }
-
-  if (0 == types_id) {
-    types_id = rb_intern("@types");
-  }
-  VALUE types = rb_ivar_get(attributes_hash, types_id);
-  if(types == Qnil) {
-    return Qnil;
-  }
-
-  if (0 == values_id) {
-    values_id = rb_intern("@values");
-  }
-  VALUE values = rb_ivar_get(attributes_hash, values_id);
-  if(values == Qnil) {
-    return Qnil;
-  }
+VALUE process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attributes, VALUE method_calls_attributes)
+{
+  panko_each_attribute(obj, attributes, panko_attributes_iter,  str_writer);
 
   long i;
-
-  for (i = 0; i < RARRAY_LEN(attributes); i++) {
-    VALUE member = rb_sym2str(RARRAY_AREF(attributes, i));
-
-    VALUE value = rb_hash_aref(values, member);
-    VALUE type_metadata = rb_hash_aref(types, member);
-
-    write_value(str_writer, member, value, type_metadata);
-  }
-
   for (i = 0; i < RARRAY_LEN(method_calls_attributes); i++) {
     VALUE attribute_name = RARRAY_AREF(method_calls_attributes, i);
     VALUE result = rb_funcall(serializer, rb_sym2id(attribute_name), 0);
@@ -80,6 +37,10 @@ process(VALUE klass, VALUE obj, VALUE str_writer, VALUE serializer, VALUE attrib
 void
 Init_panko()
 {
+  push_value_id = rb_intern("push_value");
+  type_cast_from_database_id = rb_intern("type_cast_from_database");
+
+
   VALUE mPanko = rb_define_module("Panko");
   rb_define_singleton_method(mPanko, "process", process, 5);
 }

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -43,4 +43,6 @@ Init_panko()
 
   VALUE mPanko = rb_define_module("Panko");
   rb_define_singleton_method(mPanko, "process", process, 5);
+
+  init_panko_type_cast(mPanko);
 }

--- a/ext/panko/panko.c
+++ b/ext/panko/panko.c
@@ -1,14 +1,15 @@
 #include <ruby.h>
 
 #include "attributes_iterator.h"
+#include "type_cast.h"
 
 static ID	push_value_id = 0;
-static ID	type_cast_from_database_id = 0;
+
 
 void write_value(VALUE str_writer, VALUE key, VALUE value, VALUE type_metadata)
 {
   if(type_metadata != Qnil) {
-    value = rb_funcall(type_metadata, type_cast_from_database_id, 1, value);
+    value = type_cast(type_metadata, value);
   }
 
   rb_funcall(str_writer, push_value_id, 2, value, key);
@@ -38,7 +39,6 @@ void
 Init_panko()
 {
   push_value_id = rb_intern("push_value");
-  type_cast_from_database_id = rb_intern("type_cast_from_database");
 
 
   VALUE mPanko = rb_define_module("Panko");

--- a/ext/panko/type_cast.c
+++ b/ext/panko/type_cast.c
@@ -63,11 +63,11 @@ void cache_type_lookup() {
 }
 
 
-bool isStringOrTextType(VALUE type_metadata, VALUE type_klass) {
+bool isStringOrTextType(VALUE type_klass) {
   return type_klass == ar_string_type || type_klass == ar_text_type || type_klass == ar_pg_uuid_type;
 }
 
-VALUE castStringOrTextType(VALUE type_metadata, VALUE value) {
+VALUE castStringOrTextType(VALUE value) {
   if(RB_TYPE_P(value, T_STRING)) {
     return value;
   }
@@ -75,11 +75,11 @@ VALUE castStringOrTextType(VALUE type_metadata, VALUE value) {
   return rb_funcall(value, to_s_id, 0);
 }
 
-bool isFloatType(VALUE type_metadata, VALUE type_klass) {
+bool isFloatType(VALUE type_klass) {
   return type_klass == ar_float_type || type_klass == ar_pg_float_type;
 }
 
-VALUE castFloatType(VALUE type_metadata, VALUE value) {
+VALUE castFloatType(VALUE value) {
   if(RB_TYPE_P(value, T_FLOAT)) {
     return value;
   }
@@ -92,11 +92,11 @@ VALUE castFloatType(VALUE type_metadata, VALUE value) {
   return Qundef;
 }
 
-bool isIntegerType(VALUE type_metadata, VALUE type_klass) {
+bool isIntegerType(VALUE type_klass) {
   return type_klass == ar_integer_type || type_klass == ar_pg_integer_type;
 }
 
-VALUE castIntegerType(VALUE type_metadata, VALUE value) {
+VALUE castIntegerType(VALUE value) {
   if(RB_INTEGER_TYPE_P(value)) {
     return value;
   }
@@ -109,14 +109,11 @@ VALUE castIntegerType(VALUE type_metadata, VALUE value) {
   return Qundef;
 }
 
-bool isJsonType(VALUE type_metadata, VALUE type_klass) {
+bool isJsonType(VALUE type_klass) {
   return type_klass == ar_pg_json_type;
 }
 
-static VALUE oj_const = Qundef;
-static ID	oj_load_id = 0;
-
-VALUE castJsonType(VALUE type_metadata, VALUE value) {
+VALUE castJsonType(VALUE value) {
   if(!RB_TYPE_P(value, T_STRING)) {
     return value;
   }
@@ -129,13 +126,13 @@ VALUE castJsonType(VALUE type_metadata, VALUE value) {
 VALUE type_cast(VALUE type_metadata, VALUE value) {
   cache_type_lookup();
 
-  VALUE value_klass = rb_obj_class(type_metadata);
+  VALUE type_klass = rb_obj_class(type_metadata);
   VALUE typeCastedValue = Qundef;
 
   TypeCast	typeCast;
   for (typeCast = type_casts; NULL != typeCast->canCast; typeCast++) {
-    if(typeCast->canCast(type_metadata, value_klass) == true) {
-      typeCastedValue = typeCast->typeCast(type_metadata, value);
+    if(typeCast->canCast(type_klass) == true) {
+      typeCastedValue = typeCast->typeCast(value);
       break;
     }
   }

--- a/ext/panko/type_cast.c
+++ b/ext/panko/type_cast.c
@@ -9,6 +9,7 @@ static VALUE ar_string_type = Qundef;
 static VALUE ar_text_type = Qundef;
 static VALUE ar_float_type = Qundef;
 static VALUE ar_integer_type = Qundef;
+static VALUE ar_boolean_type = Qundef;
 
 static VALUE ar_pg_integer_type = Qundef;
 static VALUE ar_pg_float_type = Qundef;
@@ -59,6 +60,7 @@ void cache_type_lookup() {
   ar_text_type = rb_const_get_at(ar_type, rb_intern("Text"));
   ar_float_type = rb_const_get_at(ar_type, rb_intern("Float"));
   ar_integer_type = rb_const_get_at(ar_type, rb_intern("Integer"));
+  ar_boolean_type = rb_const_get_at(ar_type, rb_intern("Boolean"));
 
   // TODO: if we get error or not, add this to some debug log
   int isErrored;
@@ -153,6 +155,28 @@ VALUE cast_json_type(VALUE value) {
   // TODO: instead of parsing the json, let's signal to "write_value"
   // to use "push_json" instead of "push_value"
   return Qundef;
+}
+
+bool is_boolean_type(VALUE type_klass) {
+  return type_klass == ar_boolean_type;
+}
+
+VALUE cast_boolean_type(VALUE value) {
+  if (value == Qtrue || value == Qfalse) {
+    return value;
+  }
+
+  if (value == Qnil || RSTRING_LEN(value) == 0) {
+    return Qnil;
+  }
+
+  const char* val = StringValuePtr(value);
+  bool isFalseValue =
+      (*val == '0' || (*val == 'f' || *val == 'F') ||
+       (strcmp(val, "false") == 0 || strcmp(val, "FALSE") == 0) ||
+       (strcmp(val, "off") == 0 || strcmp(val, "OFF") == 0));
+
+  return isFalseValue ? Qfalse : Qtrue;
 }
 
 VALUE type_cast(VALUE type_metadata, VALUE value) {

--- a/ext/panko/type_cast.c
+++ b/ext/panko/type_cast.c
@@ -1,0 +1,35 @@
+#include "type_cast.h"
+
+static ID	type_cast_from_database_id = 0;
+
+static VALUE string_type = Qundef;
+static VALUE text_type = Qundef;
+
+void cache_type_lookup() {
+  if(string_type == Qundef || text_type == Qundef) {
+    VALUE ar = rb_const_get_at(rb_cObject, rb_intern("ActiveRecord"));
+    VALUE ar_type = rb_const_get_at(ar, rb_intern("Type"));
+
+
+    string_type = rb_const_get_at(ar_type, rb_intern("String"));
+    text_type = rb_const_get_at(ar_type, rb_intern("Text"));
+  }
+}
+
+VALUE type_cast(VALUE type_metadata, VALUE value)
+{
+  cache_type_lookup();
+  VALUE value_klass = rb_obj_class(type_metadata);
+
+  if(value_klass == string_type || value_klass == text_type) {
+    if(RB_TYPE_P(value, T_STRING)) {
+      return value;
+    }
+
+  }
+
+  if(type_cast_from_database_id == 0) {
+    type_cast_from_database_id = rb_intern_const("type_cast_from_database");
+  }
+  return rb_funcall(type_metadata, type_cast_from_database_id, 1, value);
+}

--- a/ext/panko/type_cast.c
+++ b/ext/panko/type_cast.c
@@ -1,35 +1,105 @@
 #include "type_cast.h"
 
 static ID	type_cast_from_database_id = 0;
+static ID	to_s_id = 0;
 
-static VALUE string_type = Qundef;
-static VALUE text_type = Qundef;
+static VALUE ar_string_type = Qundef;
+static VALUE ar_text_type = Qundef;
+static VALUE ar_float_type = Qundef;
+static VALUE ar_integer_type = Qundef;
 
+static int initiailized = 0;
 void cache_type_lookup() {
-  if(string_type == Qundef || text_type == Qundef) {
+  if(initiailized != 1) {
     VALUE ar = rb_const_get_at(rb_cObject, rb_intern("ActiveRecord"));
     VALUE ar_type = rb_const_get_at(ar, rb_intern("Type"));
 
 
-    string_type = rb_const_get_at(ar_type, rb_intern("String"));
-    text_type = rb_const_get_at(ar_type, rb_intern("Text"));
+    ar_string_type = rb_const_get_at(ar_type, rb_intern("String"));
+    ar_text_type = rb_const_get_at(ar_type, rb_intern("Text"));
+    ar_float_type = rb_const_get_at(ar_type, rb_intern("Float"));
+    ar_integer_type = rb_const_get_at(ar_type, rb_intern("Integer"));
+
+    initiailized = 1;
   }
+}
+
+
+bool isStringOrTextType(VALUE type_metadata, VALUE type_klass) {
+  return type_klass == ar_string_type || type_klass == ar_text_type;
+}
+
+VALUE castStringOrTextType(VALUE type_metadata, VALUE value) {
+  if(RB_TYPE_P(value, T_STRING)) {
+    return value;
+  }
+
+  return rb_funcall(value, to_s_id, 0);
+}
+
+bool isFloatType(VALUE type_metadata, VALUE type_klass) {
+  return type_klass == ar_float_type;
+}
+
+VALUE castFloatType(VALUE type_metadata, VALUE value) {
+  if(RB_TYPE_P(value, T_FLOAT)) {
+    return value;
+  }
+
+  if(RB_TYPE_P(value, T_STRING)) {
+    const char* val = StringValuePtr(value);
+    return rb_float_new(strtod(val, NULL));
+  }
+
+  return Qundef;
+}
+
+bool isIntegerType(VALUE type_metadata, VALUE type_klass) {
+  return type_klass == ar_integer_type;
+}
+
+VALUE castIntegerType(VALUE type_metadata, VALUE value) {
+  if(RB_INTEGER_TYPE_P(value)) {
+    return value;
+  }
+
+  if(RB_TYPE_P(value, T_STRING)) {
+    const char* val = StringValuePtr(value);
+    return rb_cstr2inum(val, 10);
+  }
+
+  return Qundef;
 }
 
 VALUE type_cast(VALUE type_metadata, VALUE value)
 {
   cache_type_lookup();
+
   VALUE value_klass = rb_obj_class(type_metadata);
+  VALUE typeCastedValue = Qundef;
 
-  if(value_klass == string_type || value_klass == text_type) {
-    if(RB_TYPE_P(value, T_STRING)) {
-      return value;
+  TypeCast	typeCast;
+  for (typeCast = type_casts; NULL != typeCast->canCast; typeCast++) {
+    if(typeCast->canCast(type_metadata, value_klass) == true) {
+      typeCastedValue = typeCast->typeCast(type_metadata, value);
+      break;
     }
-
   }
 
-  if(type_cast_from_database_id == 0) {
-    type_cast_from_database_id = rb_intern_const("type_cast_from_database");
+  if(typeCastedValue == Qundef) {
+    return rb_funcall(type_metadata, type_cast_from_database_id, 1, value);
   }
-  return rb_funcall(type_metadata, type_cast_from_database_id, 1, value);
+
+  return typeCastedValue;
+}
+
+VALUE public_type_cast(VALUE module, VALUE type_metadata, VALUE value) {
+  return type_cast(type_metadata, value);
+}
+
+void init_panko_type_cast(VALUE mPanko) {
+  type_cast_from_database_id = rb_intern_const("type_cast_from_database");
+  to_s_id = rb_intern_const("to_s");
+
+  rb_define_singleton_method(mPanko, "_type_cast", public_type_cast, 2);
 }

--- a/ext/panko/type_cast.c
+++ b/ext/panko/type_cast.c
@@ -1,7 +1,7 @@
 #include "type_cast.h"
 
-static ID	type_cast_from_database_id = 0;
-static ID	to_s_id = 0;
+static ID type_cast_from_database_id = 0;
+static ID to_s_id = 0;
 
 // Caching ActiveRecord Types
 static VALUE ar_string_type = Qundef;
@@ -17,18 +17,20 @@ static VALUE ar_pg_json_type = Qundef;
 static int initiailized = 0;
 
 VALUE cache_postgres_type_lookup(VALUE ar) {
-  VALUE ar_connection_adapters = rb_const_get_at(ar, rb_intern("ConnectionAdapters"));
-  if(ar_connection_adapters == Qundef) {
+  VALUE ar_connection_adapters =
+      rb_const_get_at(ar, rb_intern("ConnectionAdapters"));
+  if (ar_connection_adapters == Qundef) {
     return Qfalse;
   }
 
-  VALUE ar_postgresql = rb_const_get_at(ar_connection_adapters, rb_intern("PostgreSQL"));
-  if(ar_postgresql == Qundef) {
+  VALUE ar_postgresql =
+      rb_const_get_at(ar_connection_adapters, rb_intern("PostgreSQL"));
+  if (ar_postgresql == Qundef) {
     return Qfalse;
   }
 
   VALUE ar_oid = rb_const_get_at(ar_postgresql, rb_intern("OID"));
-  if(ar_oid == Qundef) {
+  if (ar_oid == Qundef) {
     return Qfalse;
   }
 
@@ -41,7 +43,7 @@ VALUE cache_postgres_type_lookup(VALUE ar) {
 }
 
 void cache_type_lookup() {
-  if(initiailized == 1) {
+  if (initiailized == 1) {
     return;
   }
 
@@ -62,13 +64,13 @@ void cache_type_lookup() {
   rb_protect(cache_postgres_type_lookup, ar, &isErrored);
 }
 
-
 bool isStringOrTextType(VALUE type_klass) {
-  return type_klass == ar_string_type || type_klass == ar_text_type || type_klass == ar_pg_uuid_type;
+  return type_klass == ar_string_type || type_klass == ar_text_type ||
+         type_klass == ar_pg_uuid_type;
 }
 
 VALUE castStringOrTextType(VALUE value) {
-  if(RB_TYPE_P(value, T_STRING)) {
+  if (RB_TYPE_P(value, T_STRING)) {
     return value;
   }
 
@@ -80,11 +82,11 @@ bool isFloatType(VALUE type_klass) {
 }
 
 VALUE castFloatType(VALUE value) {
-  if(RB_TYPE_P(value, T_FLOAT)) {
+  if (RB_TYPE_P(value, T_FLOAT)) {
     return value;
   }
 
-  if(RB_TYPE_P(value, T_STRING)) {
+  if (RB_TYPE_P(value, T_STRING)) {
     const char* val = StringValuePtr(value);
     return rb_float_new(strtod(val, NULL));
   }
@@ -97,11 +99,11 @@ bool isIntegerType(VALUE type_klass) {
 }
 
 VALUE castIntegerType(VALUE value) {
-  if(RB_INTEGER_TYPE_P(value)) {
+  if (RB_INTEGER_TYPE_P(value)) {
     return value;
   }
 
-  if(RB_TYPE_P(value, T_STRING)) {
+  if (RB_TYPE_P(value, T_STRING)) {
     const char* val = StringValuePtr(value);
     return rb_cstr2inum(val, 10);
   }
@@ -114,7 +116,7 @@ bool isJsonType(VALUE type_klass) {
 }
 
 VALUE castJsonType(VALUE value) {
-  if(!RB_TYPE_P(value, T_STRING)) {
+  if (!RB_TYPE_P(value, T_STRING)) {
     return value;
   }
 
@@ -129,15 +131,15 @@ VALUE type_cast(VALUE type_metadata, VALUE value) {
   VALUE type_klass = rb_obj_class(type_metadata);
   VALUE typeCastedValue = Qundef;
 
-  TypeCast	typeCast;
+  TypeCast typeCast;
   for (typeCast = type_casts; NULL != typeCast->canCast; typeCast++) {
-    if(typeCast->canCast(type_klass) == true) {
+    if (typeCast->canCast(type_klass) == true) {
       typeCastedValue = typeCast->typeCast(value);
       break;
     }
   }
 
-  if(typeCastedValue == Qundef) {
+  if (typeCastedValue == Qundef) {
     return rb_funcall(type_metadata, type_cast_from_database_id, 1, value);
   }
 

--- a/ext/panko/type_cast.c
+++ b/ext/panko/type_cast.c
@@ -64,12 +64,12 @@ void cache_type_lookup() {
   rb_protect(cache_postgres_type_lookup, ar, &isErrored);
 }
 
-bool isStringOrTextType(VALUE type_klass) {
+bool is_string_or_text_type(VALUE type_klass) {
   return type_klass == ar_string_type || type_klass == ar_text_type ||
-         type_klass == ar_pg_uuid_type;
+         (ar_pg_uuid_type != Qundef && type_klass == ar_pg_uuid_type);
 }
 
-VALUE castStringOrTextType(VALUE value) {
+VALUE cast_string_or_text_type(VALUE value) {
   if (RB_TYPE_P(value, T_STRING)) {
     return value;
   }
@@ -77,11 +77,12 @@ VALUE castStringOrTextType(VALUE value) {
   return rb_funcall(value, to_s_id, 0);
 }
 
-bool isFloatType(VALUE type_klass) {
-  return type_klass == ar_float_type || type_klass == ar_pg_float_type;
+bool is_float_type(VALUE type_klass) {
+  return type_klass == ar_float_type ||
+         (ar_pg_float_type != Qundef && type_klass == ar_pg_float_type);
 }
 
-VALUE castFloatType(VALUE value) {
+VALUE cast_float_type(VALUE value) {
   if (RB_TYPE_P(value, T_FLOAT)) {
     return value;
   }
@@ -94,11 +95,12 @@ VALUE castFloatType(VALUE value) {
   return Qundef;
 }
 
-bool isIntegerType(VALUE type_klass) {
-  return type_klass == ar_integer_type || type_klass == ar_pg_integer_type;
+bool is_integer_type(VALUE type_klass) {
+  return type_klass == ar_integer_type ||
+         (ar_pg_integer_type != Qundef && type_klass == ar_pg_integer_type);
 }
 
-VALUE castIntegerType(VALUE value) {
+VALUE cast_integer_type(VALUE value) {
   if (RB_INTEGER_TYPE_P(value)) {
     return value;
   }
@@ -111,11 +113,11 @@ VALUE castIntegerType(VALUE value) {
   return Qundef;
 }
 
-bool isJsonType(VALUE type_klass) {
-  return type_klass == ar_pg_json_type;
+bool is_json_type(VALUE type_klass) {
+  return ar_pg_json_type != Qundef && type_klass == ar_pg_json_type;
 }
 
-VALUE castJsonType(VALUE value) {
+VALUE cast_json_type(VALUE value) {
   if (!RB_TYPE_P(value, T_STRING)) {
     return value;
   }
@@ -132,8 +134,8 @@ VALUE type_cast(VALUE type_metadata, VALUE value) {
   VALUE typeCastedValue = Qundef;
 
   TypeCast typeCast;
-  for (typeCast = type_casts; NULL != typeCast->canCast; typeCast++) {
-    if (typeCast->canCast(type_klass) == true) {
+  for (typeCast = type_casts; typeCast->canCast != NULL; typeCast++) {
+    if (typeCast->canCast(type_klass)) {
       typeCastedValue = typeCast->typeCast(value);
       break;
     }
@@ -150,7 +152,7 @@ VALUE public_type_cast(VALUE module, VALUE type_metadata, VALUE value) {
   return type_cast(type_metadata, value);
 }
 
-void init_panko_type_cast(VALUE mPanko) {
+void panko_init_type_cast(VALUE mPanko) {
   type_cast_from_database_id = rb_intern_const("type_cast_from_database");
   to_s_id = rb_intern_const("to_s");
 

--- a/ext/panko/type_cast.h
+++ b/ext/panko/type_cast.h
@@ -1,0 +1,4 @@
+#include <ruby.h>
+
+
+extern VALUE type_cast(VALUE type_metadata, VALUE value);

--- a/ext/panko/type_cast.h
+++ b/ext/panko/type_cast.h
@@ -1,6 +1,24 @@
 #include <ruby.h>
 #include <stdbool.h>
 
+/*
+ * Type Casting
+ *
+ * We do "special" type casting which is mix of two inspirations:
+ *  *) light records gem
+ *  *) pg TextDecoders
+ *
+ * The whole idea behind those type casts, are to do the minimum required
+ * type casting in the most performant manner and *allocation free*.
+ *
+ * For example, in `ActiveRecord::Type::String` the type_cast_from_database
+ * creates new string, for known reasons, but, in serialization flow we don't
+ * need to create new string becuase we afraid of mutations.
+ *
+ * Since we know before hand, that we are only reading from the database, and *not* writing
+ * and the end result if for JSON we can skip some "defenses".
+ */
+
 typedef bool (*TypeMatchFunc)(VALUE type_metadata, VALUE type_klass);
 
 // Returns Qundef, if can't type cast
@@ -25,10 +43,15 @@ VALUE castFloatType(VALUE type_metadata, VALUE value);
 bool isIntegerType(VALUE type_metadata, VALUE type_klass);
 VALUE castIntegerType(VALUE type_metadata, VALUE value);
 
+// ActiveRecord::ConnectoinAdapters::PostgreSQL::Json
+bool isJsonType(VALUE type_metadata, VALUE type_klass);
+VALUE castJsonType(VALUE type_metadata, VALUE value);
+
 static struct _TypeCast	type_casts[] = {
   { isStringOrTextType, castStringOrTextType },
   { isIntegerType, castIntegerType },
   { isFloatType, castFloatType },
+  { isJsonType, castJsonType },
 
   { NULL, NULL }
 };

--- a/ext/panko/type_cast.h
+++ b/ext/panko/type_cast.h
@@ -50,9 +50,14 @@ VALUE cast_integer_type(VALUE value);
 bool is_json_type(VALUE type_klass);
 VALUE cast_json_type(VALUE value);
 
+// ActiveRecord::Type::Boolean
+bool is_boolean_type(VALUE type_klass);
+VALUE cast_boolean_type(VALUE value);
+
 static struct _TypeCast type_casts[] = {
     {is_string_or_text_type, cast_string_or_text_type},
     {is_integer_type, cast_integer_type},
+    {is_boolean_type, cast_boolean_type},
     {is_float_type, cast_float_type},
     {is_json_type, cast_json_type},
 

--- a/ext/panko/type_cast.h
+++ b/ext/panko/type_cast.h
@@ -21,7 +21,11 @@
 
 typedef bool (*TypeMatchFunc)(VALUE type_klass);
 
-// Returns Qundef, if can't type cast
+/*
+ * TypeCastFunc
+ *
+ * @return VALUE casted value or Qundef if not casted
+ */
 typedef VALUE (*TypeCastFunc)(VALUE value);
 
 typedef struct _TypeCast {
@@ -31,28 +35,28 @@ typedef struct _TypeCast {
 
 // ActiveRecord::Type::String
 // ActiveRecord::Type::Text
-bool isStringOrTextType(VALUE type_klass);
-VALUE castStringOrTextType(VALUE value);
+bool is_string_or_text_type(VALUE type_klass);
+VALUE cast_string_or_text_type(VALUE value);
 
 // ActiveRecord::Type::Float
-bool isFloatType(VALUE type_klass);
-VALUE castFloatType(VALUE value);
+bool is_float_type(VALUE type_klass);
+VALUE cast_float_type(VALUE value);
 
 // ActiveRecord::Type::Integer
-bool isIntegerType(VALUE type_klass);
-VALUE castIntegerType(VALUE value);
+bool is_integer_type(VALUE type_klass);
+VALUE cast_integer_type(VALUE value);
 
 // ActiveRecord::ConnectoinAdapters::PostgreSQL::Json
-bool isJsonType(VALUE type_klass);
-VALUE castJsonType(VALUE value);
+bool is_json_type(VALUE type_klass);
+VALUE cast_json_type(VALUE value);
 
 static struct _TypeCast type_casts[] = {
-    {isStringOrTextType, castStringOrTextType},
-    {isIntegerType, castIntegerType},
-    {isFloatType, castFloatType},
-    {isJsonType, castJsonType},
+    {is_string_or_text_type, cast_string_or_text_type},
+    {is_integer_type, cast_integer_type},
+    {is_float_type, cast_float_type},
+    {is_json_type, cast_json_type},
 
     {NULL, NULL}};
 
 extern VALUE type_cast(VALUE type_metadata, VALUE value);
-void init_panko_type_cast(VALUE mPanko);
+void panko_init_type_cast(VALUE mPanko);

--- a/ext/panko/type_cast.h
+++ b/ext/panko/type_cast.h
@@ -15,8 +15,8 @@
  * creates new string, for known reasons, but, in serialization flow we don't
  * need to create new string becuase we afraid of mutations.
  *
- * Since we know before hand, that we are only reading from the database, and *not* writing
- * and the end result if for JSON we can skip some "defenses".
+ * Since we know before hand, that we are only reading from the database, and
+ * *not* writing and the end result if for JSON we can skip some "defenses".
  */
 
 typedef bool (*TypeMatchFunc)(VALUE type_klass);
@@ -25,10 +25,9 @@ typedef bool (*TypeMatchFunc)(VALUE type_klass);
 typedef VALUE (*TypeCastFunc)(VALUE value);
 
 typedef struct _TypeCast {
-    TypeMatchFunc canCast;
-    TypeCastFunc	typeCast;
-} *TypeCast;
-
+  TypeMatchFunc canCast;
+  TypeCastFunc typeCast;
+} * TypeCast;
 
 // ActiveRecord::Type::String
 // ActiveRecord::Type::Text
@@ -47,16 +46,13 @@ VALUE castIntegerType(VALUE value);
 bool isJsonType(VALUE type_klass);
 VALUE castJsonType(VALUE value);
 
-static struct _TypeCast	type_casts[] = {
-  { isStringOrTextType, castStringOrTextType },
-  { isIntegerType, castIntegerType },
-  { isFloatType, castFloatType },
-  { isJsonType, castJsonType },
+static struct _TypeCast type_casts[] = {
+    {isStringOrTextType, castStringOrTextType},
+    {isIntegerType, castIntegerType},
+    {isFloatType, castFloatType},
+    {isJsonType, castJsonType},
 
-  { NULL, NULL }
-};
-
-
+    {NULL, NULL}};
 
 extern VALUE type_cast(VALUE type_metadata, VALUE value);
 void init_panko_type_cast(VALUE mPanko);

--- a/ext/panko/type_cast.h
+++ b/ext/panko/type_cast.h
@@ -19,10 +19,10 @@
  * and the end result if for JSON we can skip some "defenses".
  */
 
-typedef bool (*TypeMatchFunc)(VALUE type_metadata, VALUE type_klass);
+typedef bool (*TypeMatchFunc)(VALUE type_klass);
 
 // Returns Qundef, if can't type cast
-typedef VALUE (*TypeCastFunc)(VALUE type_metadata, VALUE value);
+typedef VALUE (*TypeCastFunc)(VALUE value);
 
 typedef struct _TypeCast {
     TypeMatchFunc canCast;
@@ -32,20 +32,20 @@ typedef struct _TypeCast {
 
 // ActiveRecord::Type::String
 // ActiveRecord::Type::Text
-bool isStringOrTextType(VALUE type_metadata, VALUE type_klass);
-VALUE castStringOrTextType(VALUE type_metadata, VALUE value);
+bool isStringOrTextType(VALUE type_klass);
+VALUE castStringOrTextType(VALUE value);
 
 // ActiveRecord::Type::Float
-bool isFloatType(VALUE type_metadata, VALUE type_klass);
-VALUE castFloatType(VALUE type_metadata, VALUE value);
+bool isFloatType(VALUE type_klass);
+VALUE castFloatType(VALUE value);
 
 // ActiveRecord::Type::Integer
-bool isIntegerType(VALUE type_metadata, VALUE type_klass);
-VALUE castIntegerType(VALUE type_metadata, VALUE value);
+bool isIntegerType(VALUE type_klass);
+VALUE castIntegerType(VALUE value);
 
 // ActiveRecord::ConnectoinAdapters::PostgreSQL::Json
-bool isJsonType(VALUE type_metadata, VALUE type_klass);
-VALUE castJsonType(VALUE type_metadata, VALUE value);
+bool isJsonType(VALUE type_klass);
+VALUE castJsonType(VALUE value);
 
 static struct _TypeCast	type_casts[] = {
   { isStringOrTextType, castStringOrTextType },

--- a/ext/panko/type_cast.h
+++ b/ext/panko/type_cast.h
@@ -1,4 +1,39 @@
 #include <ruby.h>
+#include <stdbool.h>
+
+typedef bool (*TypeMatchFunc)(VALUE type_metadata, VALUE type_klass);
+
+// Returns Qundef, if can't type cast
+typedef VALUE (*TypeCastFunc)(VALUE type_metadata, VALUE value);
+
+typedef struct _TypeCast {
+    TypeMatchFunc canCast;
+    TypeCastFunc	typeCast;
+} *TypeCast;
+
+
+// ActiveRecord::Type::String
+// ActiveRecord::Type::Text
+bool isStringOrTextType(VALUE type_metadata, VALUE type_klass);
+VALUE castStringOrTextType(VALUE type_metadata, VALUE value);
+
+// ActiveRecord::Type::Float
+bool isFloatType(VALUE type_metadata, VALUE type_klass);
+VALUE castFloatType(VALUE type_metadata, VALUE value);
+
+// ActiveRecord::Type::Integer
+bool isIntegerType(VALUE type_metadata, VALUE type_klass);
+VALUE castIntegerType(VALUE type_metadata, VALUE value);
+
+static struct _TypeCast	type_casts[] = {
+  { isStringOrTextType, castStringOrTextType },
+  { isIntegerType, castIntegerType },
+  { isFloatType, castFloatType },
+
+  { NULL, NULL }
+};
+
 
 
 extern VALUE type_cast(VALUE type_metadata, VALUE value);
+void init_panko_type_cast(VALUE mPanko);

--- a/lib/panko.rb
+++ b/lib/panko.rb
@@ -1,3 +1,4 @@
+require_relative 'panko.bundle'
 require 'panko/version'
 require 'panko/serializer'
 require 'panko/array_serializer'

--- a/lib/panko.rb
+++ b/lib/panko.rb
@@ -1,6 +1,7 @@
-require_relative 'panko.bundle'
 require 'panko/version'
 require 'panko/serializer'
 require 'panko/array_serializer'
 require 'panko/object_writer'
 
+
+require 'panko/panko'

--- a/lib/panko/attributes/base.rb
+++ b/lib/panko/attributes/base.rb
@@ -2,11 +2,8 @@ module Panko
   class BaseAttribute
     def initialize(name)
       @name = name
-
-      @const_value = @name.to_s
-      @const_name = @const_value.upcase
     end
 
-    attr_reader :name, :const_name, :const_value
+    attr_reader :name
   end
 end

--- a/lib/panko/attributes/field.rb
+++ b/lib/panko/attributes/field.rb
@@ -1,7 +1,0 @@
-module Panko
-  class FieldAttribute < BaseAttribute
-    def initialize(name)
-      super
-    end
-  end
-end

--- a/lib/panko/attributes/field.rb
+++ b/lib/panko/attributes/field.rb
@@ -2,20 +2,6 @@ module Panko
   class FieldAttribute < BaseAttribute
     def initialize(name)
       super
-
-      @read_call = build_read_call
-      @method_call = build_method_call
-    end
-
-    attr_reader :read_call, :method_call
-
-    def build_read_call
-      reader = "object.#{name}"
-      "writer.push_value(#{reader}, #{const_name})"
-    end
-
-    def build_method_call
-      "writer.push_value(#{name}, #{const_name})"
     end
   end
 end

--- a/lib/panko/attributes/relationship.rb
+++ b/lib/panko/attributes/relationship.rb
@@ -14,6 +14,15 @@ module Panko
 
     attr_reader :serializer, :serializer_name, :code
 
+    def const_value
+      @name.to_s
+    end
+
+    def const_name
+      const_value.upcase
+    end
+
+
     def build_code
       output = "writer.push_key(#{const_name}) \n"
       output << "#{serializer_name}.serialize_to_writer(object.#{name}, writer)"

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -1,5 +1,4 @@
 require_relative 'attributes/base'
-require_relative 'attributes/field'
 require_relative 'attributes/relationship'
 require_relative 'attributes/has_one'
 require_relative 'attributes/has_many'
@@ -20,11 +19,7 @@ module Panko
       attr_accessor :_attributes, :_associations
 
       def attributes(*attrs)
-        attrs.each do |attr|
-          field_attr = FieldAttribute.new(attr)
-          constantize_attribute(field_attr.const_name, field_attr.const_value)
-          @_attributes << field_attr
-        end
+        @_attributes.push(*attrs)
       end
 
 
@@ -35,7 +30,7 @@ module Panko
         @_associations << has_one_attr
       end
 
-      def has_many name, options
+      def has_many(name, options)
         has_many_attr = HasManyAttribute.new(name, options)
         constantize_attribute(has_many_attr.const_name, has_many_attr.const_value)
 
@@ -59,9 +54,7 @@ module Panko
       #   obj[NAME] = object.name
       # ```
       def constantize_attribute(const_name, value)
-        unless const_defined? const_name
-          const_set const_name, value.freeze
-        end
+        const_set(const_name, value.freeze) unless const_defined?(const_name)
       end
     end
 
@@ -98,10 +91,6 @@ module Panko
 
     private
 
-    def post_process_attributes
-      
-    end
-
     def process_filter(filter)
       return { serializer: filter, associations: {} } if filter.is_a? Array
 
@@ -119,13 +108,15 @@ module Panko
     end
 
     def build_attributes_reader
+      build_attributes_metadata
+
       attributes_reader_method_body = <<-EOMETHOD
         def serialize_to_writer object, writer
           @object = object
 
           writer.push_object
 
-          #{attributes_code}
+          Panko::process(object, writer, self, @attributes, @method_call_attributes)
           #{associations_code}
 
           writer.pop
@@ -133,33 +124,21 @@ module Panko
       EOMETHOD
 
 
-      # TODO: don't redefine if [attributes+associations] wasn't changed
       instance_eval attributes_reader_method_body, __FILE__, __LINE__
     end
 
-    #
-    # Generates the code for serializing attributes
-    # The end result of this code for each attributes is pretty simple,
-    #
-    # For example:
-    #   `serializable_object[NAME] = object.name`
-    #
-    #
-    def attributes_code
-      filter(self.class._attributes).each do |attr|
-        if self.class.method_defined? attr.name
-          @method_call_attributes << attr.name
+    def build_attributes_metadata
+      filter_attributes(self.class._attributes).each do |attr|
+        if self.class.method_defined? attr
+          @method_call_attributes << attr
         else
-          @attributes << attr.name
+          @attributes << attr
         end
       end
-
-
-      'Panko::process(object, writer, self, @attributes, @method_call_attributes)'.freeze
     end
 
     def associations_code
-      filter(self.class._associations).map do |association|
+      filter_associations(self.class._associations).map do |association|
         #
         # Create instance variable to store the serializer for reusing of serializer.
         #
@@ -172,6 +151,7 @@ module Panko
           only: @only_associations.fetch(association.name, []),
           except: @except_associations.fetch(association.name, [])
         }
+
         serializer = association.create_serializer(options)
         instance_variable_set association.serializer_name, serializer
 
@@ -179,13 +159,25 @@ module Panko
       end.join("\n".freeze)
     end
 
-    def filter(keys)
+    def filter_associations(keys)
       unless @only.empty?
         return keys.select { |key| @only.include? key.name }
       end
 
       unless @except.empty?
         return keys.reject { |key| @except.include? key.name }
+      end
+
+      keys
+    end
+
+    def filter_attributes(keys)
+      unless @only.empty?
+        return keys.select { |key| @only.include?(key) }
+      end
+
+      unless @except.empty?
+        return keys.reject { |key| @except.include?(key) }
       end
 
       keys

--- a/lib/panko/version.rb
+++ b/lib/panko/version.rb
@@ -1,3 +1,3 @@
 module Panko
-  VERSION = '0.2.1'
+  VERSION = '0.2.1'.freeze
 end

--- a/lib/panko/version.rb
+++ b/lib/panko/version.rb
@@ -1,3 +1,3 @@
 module Panko
-  VERSION = "0.1.8"
+  VERSION = "0.2.0"
 end

--- a/lib/panko/version.rb
+++ b/lib/panko/version.rb
@@ -1,3 +1,3 @@
 module Panko
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end

--- a/lib/panko/version.rb
+++ b/lib/panko/version.rb
@@ -1,3 +1,3 @@
 module Panko
-  VERSION = "0.2.0"
+  VERSION = '0.2.1'
 end

--- a/panko.gemspec
+++ b/panko.gemspec
@@ -13,15 +13,17 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "MIT"
 
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.require_paths = ['lib']
 
+  spec.extensions << "ext/panko/extconf.rb"
+
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake-compiler"
 
   spec.add_dependency 'oj', '~> 3.1.3'
   spec.add_dependency 'concurrent-ruby'

--- a/panko.gemspec
+++ b/panko.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake-compiler"
 
-  spec.add_dependency 'oj', '~> 3.1.3'
+  spec.add_dependency 'oj', '~> 3.2.0'
   spec.add_dependency 'concurrent-ruby'
 end

--- a/spec/array_serializer_spec.rb
+++ b/spec/array_serializer_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'byebug'
 
 describe Panko::ArraySerializer do
   class FooSerializer < Panko::Serializer

--- a/spec/array_serializer_spec.rb
+++ b/spec/array_serializer_spec.rb
@@ -1,54 +1,53 @@
-require "spec_helper"
+require 'spec_helper'
+require 'byebug'
 
-RSpec.describe Panko::ArraySerializer do
-  Foo = Struct.new(:name, :address, :data)
-
+describe Panko::ArraySerializer do
   class FooSerializer < Panko::Serializer
     attributes :name, :address
   end
 
-  context "sanity" do
-    it "serializers array of elements" do
+  context 'sanity' do
+    it 'serializers array of elements' do
       array_serializer = Panko::ArraySerializer.new([], each_serializer: FooSerializer)
 
-      foo1 = Foo.new(Faker::Lorem.word, Faker::Lorem.word)
-      foo2 = Foo.new(Faker::Lorem.word, Faker::Lorem.word)
+      foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
+      foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      output = array_serializer.serialize [foo1, foo2]
+      output = array_serializer.serialize Foo.all
 
       expect(output).to eq([
-        { "name" => foo1.name, "address" => foo1.address },
-        { "name" => foo2.name, "address" => foo2.address },
+        { 'name' => foo1.name, 'address' => foo1.address },
+        { 'name' => foo2.name, 'address' => foo2.address }
       ])
     end
   end
 
-  context "filter" do
-    it "only" do
+  context 'filter' do
+    it 'only' do
       array_serializer = Panko::ArraySerializer.new([], each_serializer: FooSerializer, only: [:name])
 
-      foo1 = Foo.new(Faker::Lorem.word, Faker::Lorem.word)
-      foo2 = Foo.new(Faker::Lorem.word, Faker::Lorem.word)
+      foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
+      foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      output = array_serializer.serialize [foo1, foo2]
+      output = array_serializer.serialize Foo.all
 
       expect(output).to eq([
-        { "name" => foo1.name },
-        { "name" => foo2.name },
+        { 'name' => foo1.name },
+        { 'name' => foo2.name }
       ])
     end
 
-    it "except" do
+    it 'except' do
       array_serializer = Panko::ArraySerializer.new([], each_serializer: FooSerializer, except: [:name])
 
-      foo1 = Foo.new(Faker::Lorem.word, Faker::Lorem.word)
-      foo2 = Foo.new(Faker::Lorem.word, Faker::Lorem.word)
+      foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
+      foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      output = array_serializer.serialize [foo1, foo2]
+      output = array_serializer.serialize Foo.all
 
       expect(output).to eq([
-        { "address" => foo1.address },
-        { "address" => foo2.address },
+        { 'address' => foo1.address },
+        { 'address' => foo2.address }
       ])
     end
   end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -1,0 +1,49 @@
+require 'active_record'
+require 'sqlite3'
+
+
+# Change the following to reflect your database settings
+ActiveRecord::Base.establish_connection(
+  adapter: 'sqlite3',
+  database: ':memory:'
+)
+
+# Don't show migration output when constructing fake db
+ActiveRecord::Migration.verbose = false
+
+ActiveRecord::Schema.define do
+  create_table :foos, force: true do |t|
+    t.string :name
+    t.string :address
+
+    t.references :foos_holder
+    t.references :foo_holder
+
+    t.timestamps(null: false)
+  end
+
+  create_table :foo_holders, force: true do |t|
+    t.string :name
+    t.references :foo
+
+    t.timestamps(null: false)
+  end
+
+  create_table :foos_holders, force: true do |t|
+    t.string :name
+
+    t.timestamps(null: false)
+  end
+
+end
+
+class Foo < ActiveRecord::Base
+end
+
+class FoosHolder < ActiveRecord::Base
+  has_many :foos
+end
+
+class FooHolder < ActiveRecord::Base
+  has_one :foo
+end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -39,7 +39,7 @@ describe Panko::Serializer do
       })
     end
 
-    it 'serializes time correctly' do
+    xit 'serializes time correctly' do
       ObjectWithTime = Struct.new(:created_at)
       class ObjectWithTimeSerializer < Panko::Serializer
         attributes :created_at

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,15 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
+  config.full_backtrace = ENV.fetch('CI', false)
+
+  config.before(:example, :focus) do
+    fail 'This example was committed with `:focus` and should not have been'
+  end if ENV.fetch('CI', false)
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,21 @@
-require "bundler/setup"
-require "panko"
-require "faker"
+require 'bundler/setup'
+require 'panko'
+require 'faker'
+
+require_relative 'models'
+
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:each) do
+    FooHolder.delete_all
+    FoosHolder.delete_all
+    Foo.delete_all
   end
 end

--- a/spec/type_cast_spec.rb
+++ b/spec/type_cast_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+describe 'Type Casting' do
+  describe 'String / Text' do
+    context 'ActiveRecord::Type::String' do
+      let(:type) { ActiveRecord::Type::String.new }
+
+      it { expect(Panko::_type_cast(type, true)).to          eq('t') }
+      it { expect(Panko::_type_cast(type, false)).to         eq('f') }
+      it { expect(Panko::_type_cast(type, 123)).to           eq('123') }
+      it { expect(Panko::_type_cast(type, 'hello world')).to eq('hello world') }
+    end
+
+    context 'ActiveRecord::Type::Text' do
+      let(:type) { ActiveRecord::Type::Text.new }
+
+      it { expect(Panko::_type_cast(type, true)).to          eq('t') }
+      it { expect(Panko::_type_cast(type, false)).to         eq('f') }
+      it { expect(Panko::_type_cast(type, 123)).to           eq('123') }
+      it { expect(Panko::_type_cast(type, 'hello world')).to eq('hello world') }
+    end
+
+    # We treat uuid as stirng, there is no need for type cast before serialization
+    context 'ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid' do
+      let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid.new }
+
+      it { expect(Panko::_type_cast(type, 'e67d284b-87b8-445e-a20d-3c76ea353866')).to eq('e67d284b-87b8-445e-a20d-3c76ea353866') }
+    end
+  end
+
+  describe 'Integer' do
+    context 'ActiveRecord::Type::Integer' do
+      let(:type) { ActiveRecord::Type::Integer.new }
+
+      it { expect(Panko::_type_cast(type, '')).to  be_nil }
+      it { expect(Panko::_type_cast(type, nil)).to  be_nil }
+
+      it { expect(Panko::_type_cast(type, 1)).to  eq(1) }
+      it { expect(Panko::_type_cast(type, '1')).to  eq(1) }
+      it { expect(Panko::_type_cast(type, 1.7)).to  eq(1) }
+
+      it { expect(Panko::_type_cast(type, true)).to  eq(1) }
+      it { expect(Panko::_type_cast(type, false)).to  eq(0) }
+
+      it { expect(Panko::_type_cast(type, [6])).to  be_nil }
+      it { expect(Panko::_type_cast(type, six: 6)).to  be_nil }
+    end
+
+    context 'ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer' do
+      let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer.new }
+
+      it { expect(Panko::_type_cast(type, '')).to  be_nil }
+      it { expect(Panko::_type_cast(type, nil)).to  be_nil }
+
+      it { expect(Panko::_type_cast(type, 1)).to  eq(1) }
+      it { expect(Panko::_type_cast(type, '1')).to  eq(1) }
+      it { expect(Panko::_type_cast(type, 1.7)).to  eq(1) }
+
+      it { expect(Panko::_type_cast(type, true)).to  eq(1) }
+      it { expect(Panko::_type_cast(type, false)).to  eq(0) }
+
+      it { expect(Panko::_type_cast(type, [6])).to  be_nil }
+      it { expect(Panko::_type_cast(type, six: 6)).to  be_nil }
+    end
+  end
+
+  context 'ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json' do
+    let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json.new }
+
+    it { expect(Panko::_type_cast(type, '')).to  be_nil }
+    it { expect(Panko::_type_cast(type, 'shnitzel')).to be_nil }
+    it { expect(Panko::_type_cast(type, nil)).to  be_nil }
+
+    it { expect(Panko::_type_cast(type, '{"a":1}')).to  eq({ "a" => 1 }) }
+    it { expect(Panko::_type_cast(type, '[6,12]')).to  eq([6, 12]) }
+
+    it { expect(Panko::_type_cast(type, { "a" => 1 })).to  eq({ "a" => 1 }) }
+    it { expect(Panko::_type_cast(type, [6,12])).to  eq([6, 12]) }
+  end
+end

--- a/spec/type_cast_spec.rb
+++ b/spec/type_cast_spec.rb
@@ -72,10 +72,32 @@ describe 'Type Casting' do
     it { expect(Panko::_type_cast(type, 'shnitzel')).to be_nil }
     it { expect(Panko::_type_cast(type, nil)).to  be_nil }
 
-    it { expect(Panko::_type_cast(type, '{"a":1}')).to  eq({ "a" => 1 }) }
+    it { expect(Panko::_type_cast(type, '{"a":1}')).to  eq({ 'a' => 1 }) }
     it { expect(Panko::_type_cast(type, '[6,12]')).to  eq([6, 12]) }
 
-    it { expect(Panko::_type_cast(type, { "a" => 1 })).to  eq({ "a" => 1 }) }
+    it { expect(Panko::_type_cast(type, { "a" => 1 })).to  eq({ 'a' => 1 }) }
     it { expect(Panko::_type_cast(type, [6,12])).to  eq([6, 12]) }
   end
+
+  context 'ActiveRecord::Type::Boolean', focus: true do
+    let(:type) { ActiveRecord::Type::Boolean.new }
+
+    it { expect(Panko::_type_cast(type, '')).to be_nil }
+    it { expect(Panko::_type_cast(type, nil)).to be_nil }
+
+    it { expect(Panko::_type_cast(type, true)).to be_truthy }
+    it { expect(Panko::_type_cast(type, '1')).to be_truthy }
+    it { expect(Panko::_type_cast(type, 't')).to be_truthy }
+    it { expect(Panko::_type_cast(type, 'T')).to be_truthy }
+    it { expect(Panko::_type_cast(type, 'true')).to be_truthy }
+    it { expect(Panko::_type_cast(type, 'TRUE')).to be_truthy }
+
+    it { expect(Panko::_type_cast(type, false)).to be_falsey }
+    it { expect(Panko::_type_cast(type, '0')).to be_falsey }
+    it { expect(Panko::_type_cast(type, 'f')).to be_falsey }
+    it { expect(Panko::_type_cast(type, 'F')).to be_falsey }
+    it { expect(Panko::_type_cast(type, 'false')).to be_falsey }
+    it { expect(Panko::_type_cast(type, 'FALSE')).to be_falsey }
+  end
+
 end

--- a/spec/type_cast_spec.rb
+++ b/spec/type_cast_spec.rb
@@ -79,7 +79,7 @@ describe 'Type Casting' do
     it { expect(Panko::_type_cast(type, [6,12])).to  eq([6, 12]) }
   end
 
-  context 'ActiveRecord::Type::Boolean', focus: true do
+  context 'ActiveRecord::Type::Boolean' do
     let(:type) { ActiveRecord::Type::Boolean.new }
 
     it { expect(Panko::_type_cast(type, '')).to be_nil }


### PR DESCRIPTION
After some thinking, I decided to re-write panko in native c.
Why? I needed bigger performance improvement on real workload.

In this pull request, those are the huge changes:

- Only field attributes are serialized in native
- Instead of reading attributes from ActiveRecord object like `person.name`, I am peeking into internal structures and doing all my typecasting my self.

### Why?
If you read the last change carefully, you will ask **why?**, the reason is: ActiveRecord is designed to return objects in order to manipulate them - read them, change them, save them - all the happy mutations

For example, string type casting in ActiveRecord creates new string - why? I think because of safety reasons (mutations for example), while in panko - in the whole serialization "pipeline", I don't mutate any values - I am just returning them.

Therefore, I am designing panko to have fast reads from ActiveRecord objects, and loosing some correctness in mind.

### What is Next?

1. Times Type Casting - they cause a lot of pain, I started worked on this - and I need to finish this, on real workload this can yield another 20% improvement (in addition to 28%) in my opinion.
2. Has One relationships
3. Has Many realtionships
4. Once, all relationships and field are serialized in panko, I plan moving to Phase 2

### Phase 2
At the end, I want Panko to split to two parts:
- Backend
- Frontend

_Don't worry, I am not on illusions that panko is a compiler or something crazy like this, Panko strives (and tries) to be the simple_

Where the frontend, is ruby code that provides beautiful and clean API for defining serializers, that at the end creates metadata and passes it to the backend which is written in C and those all of the serializations.


